### PR TITLE
Add nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1722062969,
+        "narHash": "sha256-QOS0ykELUmPbrrUGmegAUlpmUFznDQeR4q7rFhl8eQg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b73c2221a46c13557b1b3be9c2070cc42cf01eb3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }: {
+
+    packages.x86_64-linux = {
+      puffin = nixpkgs.legacyPackages.x86_64-linux.buildGoModule {
+        pname = "puffin";
+        version = "git";
+        vendorHash = "sha256-XfsGXh9nz+QJEAqtw/BfzHhSVje6q0KLsVg1ZQ6fN4U=";
+        src = ./.;
+      };
+      default = self.packages.x86_64-linux.puffin;
+    };
+
+
+  };
+}


### PR DESCRIPTION
This enables building via `nix build` and running via `nix run github:siddhantac/puffin` (once merged)

Putting this here as a proposal and space for discussion. It is not exactly zero-cost:

- For releases, the version should be adjusted. This doesn't really have any effect though, so it could be skipped.
- Whenever the dependencies change, the vendorHash needs to be updated or the old dependencies will be used if cached. (I think)
  In practice, this means replacing the vendorHash with an empty string and running `nix build`, this will show the correct vendorHash like so:
  
  ```
  > nix build                       
warning: Git tree '/home/voyd/Coding/puffin' is dirty
warning: found empty hash, assuming 'sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
error: hash mismatch in fixed-output derivation '/nix/store/rncp1mikj8nmy8ai56crnwk0pdca6d50-puffin-git-go-modules.drv':
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-XfsGXh9nz+QJEAqtw/BfzHhSVje6q0KLsVg1ZQ6fN4U=
error: 1 dependencies of derivation '/nix/store/s6arm30f9rxfxw3c4s3nkis0an7zr8j5-puffin-git.drv' failed to build
```

The sha is basically used as a cache key, so if a new version in which the vendorHash wasn't updated is built on a system that already has the old dependencies cached, it will wrongly use the cache.
An obvious way to prevent this would be to run the build in the pipeline, I'd be happy to add that if that would tip the scales for you, but it's going beyond my personal needs so I'll wait for your thoughts on this.

Depending on how deep you want to get into this, nix could also be used to define the development environment and so on of course, but I was interested in this and was missing this part because it allows me not to think about compiling the application.
  